### PR TITLE
fix: use os.tmpdir

### DIFF
--- a/wd/lib/tmp.js
+++ b/wd/lib/tmp.js
@@ -39,7 +39,7 @@ function _getTMPDir() {
 
 var
   exists = fs.exists || path.exists,
-  tmpDir = os.tmpDir || _getTMPDir,
+  tmpDir = os.tmpdir || _getTMPDir,
   _TMP = tmpDir(),
   randomChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz",
   randomCharsLength = randomChars.length;


### PR DESCRIPTION
The os.tmpDir() API is deprecated. Please use os.tmpdir() instead.