### PR TITLE
Use remap when coverageOptions.useRemap is true

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -87,6 +87,10 @@ const extendsMixIn = wd => {
       });
   });
 
+  wd.addPromiseChainMethod('configCoverage', function(options) {
+    this.__coverrageOptions = options;
+  });
+
   wd.addPromiseChainMethod('coverage', function(context) {
     const coverageHtml = path.join(cwd, 'coverage', 'index.html');
     return this
@@ -100,13 +104,17 @@ const extendsMixIn = wd => {
             });
         }
         const reporter = new Reporter();
-        collector.add(__coverage__);
-        /*
-        const _collector = remap(__coverage__, {
-          warnMissingSourceMaps: false
-        });
-        collector.add(_collector.getFinalCoverage());
-        */
+
+        if (this.__coverrageOptions && this.__coverrageOptions.useRemap) {
+          const _collector = remap(__coverage__, {
+            warn: () => {},
+            warnMissingSourceMaps: false
+          });
+          collector.add(_collector.getFinalCoverage());
+        } else {
+          collector.add(__coverage__);
+        }
+
         reporter.addAll([
           'html',
           'lcov'


### PR DESCRIPTION
```
wd.addPromiseChainMethod('initBrowser', function (options = {}) {
  return this
    // 测试用例中新增 configCoverage，启用 remap
    .configCoverage({
      useRemap: true,
    })
    .initWindow({})
})

```